### PR TITLE
Move output to certificate folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/certificate

--- a/createRootCA.sh
+++ b/createRootCA.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
-openssl genrsa -des3 -out rootCA.key 2048
-openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 825 -out rootCA.pem
+set -e
+
+mkdir "certificate"
+openssl genrsa -des3 -out certificate/rootCA.key 2048
+openssl req -x509 -new -nodes -key certificate/rootCA.key -sha256 -days 825 -out certificate/rootCA.pem

--- a/createRootCA.sh
+++ b/createRootCA.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-
 mkdir "certificate"
 openssl genrsa -des3 -out certificate/rootCA.key 2048
 openssl req -x509 -new -nodes -key certificate/rootCA.key -sha256 -days 825 -out certificate/rootCA.pem

--- a/createSelfSigned.sh
+++ b/createSelfSigned.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
-openssl req -new -sha256 -nodes -out server.csr -newkey rsa:2048 -keyout server.key -config server.csr.cnf
-openssl x509 -req -in server.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out server.crt -days 825 -sha256 -extfile v3.ext
+set -e
+openssl req -new -sha256 -nodes -out certificate/server.csr -newkey rsa:2048 -keyout certificate/server.key -config server.csr.cnf
+openssl x509 -req -in certificate/server.csr -CA certificate/rootCA.pem -CAkey certificate/rootCA.key -CAcreateserial -out certificate/server.crt -days 825 -sha256 -extfile v3.ext


### PR DESCRIPTION
This PR simply change the output of the certificate to "certificate" folder  and ignore the folder to avoid dirtying the repository commits.