### PR TITLE
set root expiration to 20 years

### DIFF
--- a/createRootCA.sh
+++ b/createRootCA.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 openssl genrsa -des3 -out rootCA.key 2048
-openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 825 -out rootCA.pem
+openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 7300 -out rootCA.pem


### PR DESCRIPTION
Root can have an expiration longer than 825 days. 